### PR TITLE
Exposing .read() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This will expose the following methods
 * [Azureservice.del(tableName, obj, withFilterFn)] (#azureservicedeltablename-obj-withfilterfn)
 * [Azureservice.getAll(tableName, withFilterFn)] (#azureservicegetalltablename-withfilterfn)
 * [Azureservice.getById(tableName, id, withFilterFn)] (#azureservicegetbyidtablename-id-withfilterfn)
+* [Azureservice.read(tableName, parameters, withFilterFn)] (#azureservicereadtablename-parameters-withfilterfn)
 * [Azureservice.login(oauthProvider)] (#azureserviceloginoauthprovider)
 * [Azureservice.logout()] (#azureservicelogout)
 * [Azureservice.isLoggedIn()] (#azureserviceisloggedin)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This will expose the following methods
 
 * [Azureservice.query(tableName, parameters, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicequerytablename-parameters-withfilterfn)
 * [Azureservice.insert(tableName, obj, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureserviceinserttablename-obj-withfilterfn)
-* [Azureservice.update(tableName, obj, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service##azureserviceupdatetablename-obj-withfilterfn)
+* [Azureservice.update(tableName, obj, withFilterFn)] (#azureserviceupdatetablename-obj-withfilterfn)
 * [Azureservice.del(tableName, obj, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicedeltablename-obj-withfilterfn)
 * [Azureservice.getAll(tableName, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicegetalltablename-withfilterfn)
 * [Azureservice.getById(tableName, id, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicegetbyidtablename-id-withfilterfn)

--- a/README.md
+++ b/README.md
@@ -447,6 +447,49 @@ Azureservice.getById('todoListTable', '5A25CD78-F2D9-413C-81CA-6EC090590AAF')
     
 ```
 
+Azureservice.read(tableName, parameters, withFilterFn)
+=================
+Execute read-query in Azure with optional parameters in the URI that can be read by the Azure JS backend (request.parameters.property).
+
+Parameters:
+---------------
+**tableName** Required
+
+````
+The Azure table to get all data from
+```
+
+**parameters** Optional
+````
+An object of user-defined parameters and values to include in the request URI query string
+````
+
+**withFilterFn** Optional [More information] (http://azure.microsoft.com/en-us/documentation/articles/mobile-services-html-how-to-use-client-library/#customizing)
+
+````
+A function that can read and write arbitrary properties or add additional headers to the request  
+```
+
+Returns
+-----------
+AngularJS Promise
+
+Example
+-------------
+```javascript
+Azureservice.read('todoListTable',{
+	apiVersion: "1.0",
+	isCompleted: true
+	})
+	.then(function(items) {
+		console.log('Query successful');
+		$scope.item = items;
+	}, function(err) {
+		console.error('Azure Error: ' + err);
+	});
+    
+```
+
 
 Azureservice.login(oauthProvider)
 =================

--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ angular.module('myapp')
 
 This will expose the following methods
 
-* [Azureservice.query(tableName, parameters, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicequerytablename-parameters-withfilterfn)
-* [Azureservice.insert(tableName, obj, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureserviceinserttablename-obj-withfilterfn)
+* [Azureservice.query(tableName, parameters, withFilterFn)] (#azureservicequerytablename-parameters-withfilterfn)
+* [Azureservice.insert(tableName, obj, withFilterFn)] (#azureserviceinserttablename-obj-withfilterfn)
 * [Azureservice.update(tableName, obj, withFilterFn)] (#azureserviceupdatetablename-obj-withfilterfn)
-* [Azureservice.del(tableName, obj, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicedeltablename-obj-withfilterfn)
-* [Azureservice.getAll(tableName, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicegetalltablename-withfilterfn)
-* [Azureservice.getById(tableName, id, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicegetbyidtablename-id-withfilterfn)
-* [Azureservice.login(oauthProvider)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureserviceloginoauthprovider)
-* [Azureservice.logout()] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicelogout)
-* [Azureservice.isLoggedIn()] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureserviceisloggedin)
-* [Azureservice.invokeApi()] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureserviceinvokeapiname-params)
+* [Azureservice.del(tableName, obj, withFilterFn)] (#azureservicedeltablename-obj-withfilterfn)
+* [Azureservice.getAll(tableName, withFilterFn)] (#azureservicegetalltablename-withfilterfn)
+* [Azureservice.getById(tableName, id, withFilterFn)] (#azureservicegetbyidtablename-id-withfilterfn)
+* [Azureservice.login(oauthProvider)] (#azureserviceloginoauthprovider)
+* [Azureservice.logout()] (#azureservicelogout)
+* [Azureservice.isLoggedIn()] (#azureserviceisloggedin)
+* [Azureservice.invokeApi()] (#azureserviceinvokeapiname-params)
 
 
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ angular.module('myapp')
 
 This will expose the following methods
 
-* [Azureservice.query(tableName, parameters, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicequerytablename-parameters)
-* [Azureservice.getAll(tableName, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicegetalltablename)
-* [Azureservice.getById(tableName, id, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicegetbyidtablename-id)
-* [Azureservice.insert(tableName, obj, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureserviceinserttablename-obj)
-* [Azureservice.update(tableName, obj, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureserviceupdatetablename-obj)
-* [Azureservice.del(tableName, obj, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicedeletetablename-obj)
+* [Azureservice.query(tableName, parameters, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicequerytablename-parameters-withfilterfn)
+* [Azureservice.insert(tableName, obj, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureserviceinserttablename-obj-withfilterfn)
+* [Azureservice.update(tableName, obj, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service##azureserviceupdatetablename-obj-withfilterfn)
+* [Azureservice.del(tableName, obj, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicedeltablename-obj-withfilterfn)
+* [Azureservice.getAll(tableName, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicegetalltablename-withfilterfn)
+* [Azureservice.getById(tableName, id, withFilterFn)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicegetbyidtablename-id-withfilterfn)
 * [Azureservice.login(oauthProvider)] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureserviceloginoauthprovider)
-* [Azureservice.logout()] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureserviceloginoauthprovider-1)
+* [Azureservice.logout()] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureservicelogout)
 * [Azureservice.isLoggedIn()] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureserviceisloggedin)
 * [Azureservice.invokeApi()] (https://github.com/TerryMooreII/angular-azure-mobile-service#azureserviceinvokeapiname-params)
 
@@ -275,10 +275,6 @@ Azureservice.insert('todoListTable', {
 	});
     
 ```
-
-Returns
------------
-AngularJS Promise
 
 
 Azureservice.update(tableName, obj, withFilterFn)

--- a/angular-azure-mobile-service.js
+++ b/angular-azure-mobile-service.js
@@ -167,7 +167,7 @@ angular.module('azure-mobile-service.module', [])
          Execute read-query in Azure
 
          @param string tableName       REQUIRED The name of the table to query
-         @param function withFilterFn  OPTIONAL An object of user-defined parameters and values to include in the request URI query string
+         @param object parameters	   OPTIONAL An object of user-defined parameters and values to include in the request URI query string
          @param function withFilterFn  OPTIONAL A function that can read and write arbitrary properties or add additional headers to the request
          @return promise               Returns a WindowsAzure promise
          */

--- a/angular-azure-mobile-service.js
+++ b/angular-azure-mobile-service.js
@@ -162,6 +162,19 @@ angular.module('azure-mobile-service.module', [])
         getAll: function(tableName, withFilterFn){
             return this.query(tableName, null, withFilterFn);
         },
+		
+        /*
+         Execute read-query in Azure
+
+         @param string tableName       REQUIRED The name of the table to query
+         @param function withFilterFn  OPTIONAL An object of user-defined parameters and values to include in the request URI query string
+         @param function withFilterFn  OPTIONAL A function that can read and write arbitrary properties or add additional headers to the request
+         @return promise               Returns a WindowsAzure promise
+         */
+        read: function (tableName, parameters, withFilterFn) {
+
+            return wrapAzurePromiseWithAngularPromise(getTable(tableName, withFilterFn).read(parameters));
+        },
 
         /*
           Insert row in to Azure


### PR DESCRIPTION
In order to send parameters to the javascript backend that can be read
through request.parameters the .read() method of the azure sdk is now
exposed with angular promise wrapped around. See also
http://stackoverflow.com/questions/17415257/passing-query-parameters-from-html-js-app-to-azure-server-script