### PR TITLE
Allow sending an existing token to login with provider

### DIFF
--- a/DefinitelyTyped/AngularService.d.ts
+++ b/DefinitelyTyped/AngularService.d.ts
@@ -8,7 +8,7 @@ interface IAzureService {
     getAll<T>(tableName: string, withFilterFn?: Function): ng.IPromise<T>;
     getById<T>(tableName: string, id: string, withFilterFn?: Function): ng.IPromise<T>;
     read<T>(tableName: string, parameters?: IAzureParameters, withFilterFn?:Function): ng.IPromise<T>;
-    login(oauthProvider: string): ng.IPromise<any>;
+    login(oauthProvider: string, token: Object): ng.IPromise<any>;
     setCurrentUser(userObj: Object): void;
     getCurrentUser(): Object;
     logout(): void;

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This will expose the following methods
 * [Azureservice.getAll(tableName, withFilterFn)] (#azureservicegetalltablename-withfilterfn)
 * [Azureservice.getById(tableName, id, withFilterFn)] (#azureservicegetbyidtablename-id-withfilterfn)
 * [Azureservice.read(tableName, parameters, withFilterFn)] (#azureservicereadtablename-parameters-withfilterfn)
-* [Azureservice.login(oauthProvider)] (#azureserviceloginoauthprovider)
+* [Azureservice.login(oauthProvider, token)] (#azureserviceloginoauthprovider)
 * [Azureservice.logout()] (#azureservicelogout)
 * [Azureservice.setCurrentUser(userObj)] (#azureservicesetcurrentuseruserobj)
 * [Azureservice.getCurrentUser()] (#azureservicegetcurrentuser)
@@ -516,9 +516,9 @@ Azureservice.read('todoListTable', "$filter=name eq 'Test User'")
 
 
 
-Azureservice.login(oauthProvider)
+Azureservice.login(oauthProvider, token)
 =================
-Login using the specified Oauth Provider.
+Login using the specified OAuth Provider and optinally provide an existing authentication token.
 Users logins are currently session based.  This may change in the future.
 [More information] (http://www.windowsazure.com/en-us/documentation/articles/mobile-services-html-how-to-use-client-library/#caching)
 
@@ -528,8 +528,14 @@ Parameters:
 **oauthProvider** Required
 
 ````
-The oauth provider
+The OAuth provider
 Vaild options are 'google', 'twitter', 'facebook', 'microsoftaccount', 'aad'
+```
+
+**token** Optional
+
+````
+Optional authentication token used to login to the provider
 ```
 
 Returns
@@ -540,13 +546,21 @@ AngularJS Promise
 Example
 -------------
 ```javascript
+// New login to provider
 Azureservice.login('google')
 	.then(function() {
 		console.log('Login successful');
 	}, function(err) {
 		console.error('Azure Error: ' + err);
 	});
-    
+
+// Use existing token to login
+Azureservice.login('google', { id_token: 'qwerty12345...' })
+	.then(function() {
+		console.log('Login successful');
+	}, function(err) {
+		console.error('Azure Error: ' + err);
+	});
 ```
 
 

--- a/src/angular-azure-mobile-service.js
+++ b/src/angular-azure-mobile-service.js
@@ -283,17 +283,18 @@ angular.module('azure-mobile-service.module', [])
               Logs a user into the oauthProvider service using Windows Azure
               Stores the data in sessionStorage for future queries
         
-              @param  string oauthProvider  REQUIRED pass in an oauth provider
+              @param  string oauthProvider  REQUIRED Pass in an OAuth provider name (google, facebook, etc)
+              @param  string token          OPTIONAL An existing authentication token to login to the OAuth provider with
               @return promise               Returns a WindowsAzure promise
             */
 
-            login: function(oauthProvider) {
+            login: function(oauthProvider, token) {
 
                 if (!angular.isDefined(oauthProvider) || VAILD_OAUTH_PROVIDERS.indexOf(oauthProvider) === -1) {
                     throw new Error('Azureservice.login Invalid or no oauth provider listed.');
                 }
 
-                var promise = client.login(oauthProvider).then(function() {
+                var promise = client.login(oauthProvider, token).then(function() {
                     //cache login 
                     setCachedUser(client.currentUser);
                 });


### PR DESCRIPTION
The mobile services API allows sending in an existing token to login so
that it is not necessary to launch a provider pop-up. This is useful in
hybrid apps where the token can be retrieved through the native API and
passed in to create the session.