### PR TITLE
Updated README - missing "param" in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ This will run the criteria function against the results passing in params array.
 
 ```javascript
 Azureservice.query('todoListTable', {
- 	criteria: function() {
+ 	criteria: function(param) {
  			return this.name.indexOf(param[0]) !== -1;  // The this keyword is in referece to the Azure results
  		},
  	params: ['terry']


### PR DESCRIPTION
I just lost 2 hours finding the bug from the code in that example and the error log wasn't helpful either.
Hope that'll help others too.